### PR TITLE
Boost.Pool-related benchmarks improvements and some minor fixes.

### DIFF
--- a/Benchmark/MemoryPool/Adapters.hpp
+++ b/Benchmark/MemoryPool/Adapters.hpp
@@ -7,7 +7,7 @@
 #include <Memory/UnorderedPool.hpp>
 #include <Memory/TypedUnorderedPool.hpp>
 
-#define MEMORY_LIBRARY_PAGE_CAPACITY 256u
+#define MEMORY_LIBRARY_PAGE_CAPACITY 512u
 
 template <typename ObjectType>
 class NewDeleteAdapter

--- a/Benchmark/MemoryPool/Adapters.hpp
+++ b/Benchmark/MemoryPool/Adapters.hpp
@@ -42,6 +42,20 @@ private:
 };
 
 template <typename ObjectType>
+class OrderedTrivialBoostObjectPoolAdapter
+{
+public:
+    using EntryType = ObjectType;
+
+    ObjectType *Acquire ();
+
+    void Free (ObjectType *object);
+
+private:
+    boost::pool <boost::default_user_allocator_malloc_free> pool_ {sizeof (ObjectType)};
+};
+
+template <typename ObjectType>
 class UnorderedBoostPoolAdapter
 {
 public:
@@ -54,6 +68,21 @@ public:
 private:
     boost::pool <boost::default_user_allocator_malloc_free> pool_ {sizeof (ObjectType)};
 };
+
+template <typename ObjectType>
+class UnorderedTrivialBoostPoolAdapter
+{
+public:
+    using EntryType = ObjectType;
+
+    ObjectType *Acquire ();
+
+    void Free (ObjectType *object);
+
+private:
+    boost::pool <boost::default_user_allocator_malloc_free> pool_ {sizeof (ObjectType)};
+};
+
 
 template <typename ObjectType>
 class UnorderedPoolAdapter
@@ -152,6 +181,18 @@ void OrderedBoostObjectPoolAdapter <ObjectType>::Free (ObjectType *object)
 }
 
 template <typename ObjectType>
+ObjectType *OrderedTrivialBoostObjectPoolAdapter <ObjectType>::Acquire ()
+{
+    return reinterpret_cast<ObjectType *> (pool_.ordered_malloc ());
+}
+
+template <typename ObjectType>
+void OrderedTrivialBoostObjectPoolAdapter <ObjectType>::Free (ObjectType *object)
+{
+    pool_.ordered_free (object);
+}
+
+template <typename ObjectType>
 ObjectType *UnorderedBoostPoolAdapter <ObjectType>::Acquire ()
 {
     return new (pool_.malloc ()) ObjectType ();
@@ -161,6 +202,18 @@ template <typename ObjectType>
 void UnorderedBoostPoolAdapter <ObjectType>::Free (ObjectType *object)
 {
     object->~ObjectType ();
+    pool_.free (object);
+}
+
+template <typename ObjectType>
+ObjectType *UnorderedTrivialBoostPoolAdapter <ObjectType>::Acquire ()
+{
+    return reinterpret_cast<ObjectType *> (pool_.malloc ());
+}
+
+template <typename ObjectType>
+void UnorderedTrivialBoostPoolAdapter <ObjectType>::Free (ObjectType *object)
+{
     pool_.free (object);
 }
 

--- a/Benchmark/MemoryPool/AllocateDeallocate.cpp
+++ b/Benchmark/MemoryPool/AllocateDeallocate.cpp
@@ -69,11 +69,11 @@ BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <Component1
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component32b>);
 
@@ -81,11 +81,11 @@ BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component192b>
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedTrivialBoostPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedTrivialBoostPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedTrivialBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/AllocateDeallocate.cpp
+++ b/Benchmark/MemoryPool/AllocateDeallocate.cpp
@@ -63,17 +63,29 @@ BENCHMARK_TEMPLATE(AllocateDeallocate, NewDeleteAdapter <TrivialComponent192b>);
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, NewDeleteAdapter <TrivialComponent1032b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <Component32b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <Component32b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <Component192b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <Component192b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <Component1032b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(AllocateDeallocate, BoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(AllocateDeallocate, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component32b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component192b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <Component1032b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+
+BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(AllocateDeallocate, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/Allocation.cpp
+++ b/Benchmark/MemoryPool/Allocation.cpp
@@ -44,11 +44,11 @@ BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <Component192b>);
 
 BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component32b>);
 
@@ -56,11 +56,11 @@ BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component192b>);
 
 BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Allocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Allocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Allocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Allocation, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/Allocation.cpp
+++ b/Benchmark/MemoryPool/Allocation.cpp
@@ -38,17 +38,29 @@ BENCHMARK_TEMPLATE(Allocation, NewDeleteAdapter <TrivialComponent192b>);
 
 BENCHMARK_TEMPLATE(Allocation, NewDeleteAdapter <TrivialComponent1032b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <Component32b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <Component32b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <Component192b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <Component192b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <Component1032b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Allocation, BoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Allocation, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component32b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component192b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <Component1032b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+
+BENCHMARK_TEMPLATE(Allocation, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Allocation, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/Deallocation.cpp
+++ b/Benchmark/MemoryPool/Deallocation.cpp
@@ -60,11 +60,11 @@ BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <Component192b>);
 
 BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedTrivialBoostObjectPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component32b>);
 
@@ -72,11 +72,11 @@ BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component192b>);
 
 BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Deallocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Deallocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Deallocation, UnorderedTrivialBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Deallocation, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/Deallocation.cpp
+++ b/Benchmark/MemoryPool/Deallocation.cpp
@@ -54,17 +54,29 @@ BENCHMARK_TEMPLATE(Deallocation, NewDeleteAdapter <TrivialComponent192b>);
 
 BENCHMARK_TEMPLATE(Deallocation, NewDeleteAdapter <TrivialComponent1032b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <Component32b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <Component32b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <Component192b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <Component192b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <Component1032b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <Component1032b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <TrivialComponent32b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent32b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <TrivialComponent192b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent192b>);
 
-BENCHMARK_TEMPLATE(Deallocation, BoostObjectPoolAdapter <TrivialComponent1032b>);
+BENCHMARK_TEMPLATE(Deallocation, OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component32b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component192b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <Component1032b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent32b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent192b>);
+
+BENCHMARK_TEMPLATE(Deallocation, UnorderedBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(Deallocation, UnorderedPoolAdapter <Component32b>);
 

--- a/Benchmark/MemoryPool/MixedAllocateDeallocate.cpp
+++ b/Benchmark/MemoryPool/MixedAllocateDeallocate.cpp
@@ -103,9 +103,9 @@ BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    OrderedBoostObjectPoolAdapter <Component1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
-                   OrderedBoostObjectPoolAdapter <TrivialComponent32b>,
-                   OrderedBoostObjectPoolAdapter <TrivialComponent192b>,
-                   OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+                   OrderedTrivialBoostObjectPoolAdapter <TrivialComponent32b>,
+                   OrderedTrivialBoostObjectPoolAdapter <TrivialComponent192b>,
+                   OrderedTrivialBoostObjectPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    UnorderedBoostPoolAdapter <Component32b>,
@@ -113,9 +113,9 @@ BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    UnorderedBoostPoolAdapter <Component1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
-                   UnorderedBoostPoolAdapter <TrivialComponent32b>,
-                   UnorderedBoostPoolAdapter <TrivialComponent192b>,
-                   UnorderedBoostPoolAdapter <TrivialComponent1032b>);
+                   UnorderedTrivialBoostPoolAdapter <TrivialComponent32b>,
+                   UnorderedTrivialBoostPoolAdapter <TrivialComponent192b>,
+                   UnorderedTrivialBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    UnorderedPoolAdapter <Component32b>,

--- a/Benchmark/MemoryPool/MixedAllocateDeallocate.cpp
+++ b/Benchmark/MemoryPool/MixedAllocateDeallocate.cpp
@@ -98,14 +98,24 @@ BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    NewDeleteAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
-                   BoostObjectPoolAdapter <Component32b>,
-                   BoostObjectPoolAdapter <Component192b>,
-                   BoostObjectPoolAdapter <Component1032b>);
+                   OrderedBoostObjectPoolAdapter <Component32b>,
+                   OrderedBoostObjectPoolAdapter <Component192b>,
+                   OrderedBoostObjectPoolAdapter <Component1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
-                   BoostObjectPoolAdapter <TrivialComponent32b>,
-                   BoostObjectPoolAdapter <TrivialComponent192b>,
-                   BoostObjectPoolAdapter <TrivialComponent1032b>);
+                   OrderedBoostObjectPoolAdapter <TrivialComponent32b>,
+                   OrderedBoostObjectPoolAdapter <TrivialComponent192b>,
+                   OrderedBoostObjectPoolAdapter <TrivialComponent1032b>);
+
+BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
+                   UnorderedBoostPoolAdapter <Component32b>,
+                   UnorderedBoostPoolAdapter <Component192b>,
+                   UnorderedBoostPoolAdapter <Component1032b>);
+
+BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
+                   UnorderedBoostPoolAdapter <TrivialComponent32b>,
+                   UnorderedBoostPoolAdapter <TrivialComponent192b>,
+                   UnorderedBoostPoolAdapter <TrivialComponent1032b>);
 
 BENCHMARK_TEMPLATE(MixedAllocateDeallocate,
                    UnorderedPoolAdapter <Component32b>,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set (CMAKE_CXX_STANDARD 17)
 
 project (MemoryPool)
 
-option (RUNTIME_OUTPUT_DIRECTORY "Directory where all runtime outputs will be stored." "${CMAKE_BINARY_DIR}/Bin")
+set (RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Bin" CACHE PATH "Directory where all runtime outputs will be stored.")
 option (MEMORY_POOL_TESTS "Build MemoryPool library tests." OFF)
 option (MEMORY_POOL_BENCHMARK "Build MemoryPool library benchmark." OFF)
 

--- a/Source/Memory/UnorderedPool.cpp
+++ b/Source/Memory/UnorderedPool.cpp
@@ -56,8 +56,8 @@ SizeType UnorderedTrivialPool::GetPageCapacity () const
 UnorderedPool::UnorderedPool (SizeType pageCapacity, SizeType chunkSize,
                               Constructor constructor, Destructor destructor) noexcept
     : fields_ {nullptr, nullptr, 0u, pageCapacity, chunkSize},
-      constructor_ (std::move (constructor)),
-      destructor_ (std::move (destructor))
+      constructor_ (constructor),
+      destructor_ (destructor)
 {
     assert (constructor_);
     assert (destructor_);

--- a/Source/Memory/UnorderedPool.hpp
+++ b/Source/Memory/UnorderedPool.hpp
@@ -41,8 +41,8 @@ class UnorderedPool
 public:
     using ValueType = void;
 
-    using Constructor =  std::function <void (void *)>;
-    using Destructor =  std::function <void (void *)>;
+    using Constructor = void (*) (void *) noexcept;
+    using Destructor = void (*) (void *) noexcept;
 
     UnorderedPool (SizeType pageCapacity, SizeType chunkSize,
                    Constructor constructor, Destructor destructor) noexcept;


### PR DESCRIPTION
Benchmark:
- Add unordered and trivial benchmark adapters for `Boost.Pool` pools.
- Use `destroy` in `OrderedBoostObjectPoolAdapter::Free` to call destructor (previous implementation just called `free` because of typo).
- Use `512`-chunk pages for `MemoryPool` pools, explanation in commit d30261d comment.
- Update benchmarks with new unordered and trivial `Boost.Pool` adapters.

Build system:
- Fix incorrect declaration of `RUNTIME_OUTPUT_DIRECTORY` configuration option.

Library:
- Use function pointers instead of `std::function` as constructor and destructor in `UnorderedPool` to speed up allocation and deallocation of objects with quick constructors/destructors.

Tests:
- Update tests according to library changes.